### PR TITLE
Disable the babel option: `optimisation.react.inlineElement`.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,7 @@ gulp.task('build2', ['jslint'], function () {
     let babel = babelify.configure({
         optional: [
             'optimisation.react.constantElements',
-            'optimisation.react.inlineElements',
+            // 'optimisation.react.inlineElements', // FIXME: #17
             'utility.deadCodeElimination',
             'utility.inlineEnvironmentVariables',
             'utility.inlineExpressions',


### PR DESCRIPTION
This option will cause the following error with React 0.13 :(

> Uncaught Error: Invariant Violation: `React.render()`: Invalid component
> element. This may be caused by unintentionally loading two independent
> copies of React.


#17